### PR TITLE
Add 3D depth to game board

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,12 +33,72 @@
           0 0 120px rgba(80, 60, 200, 0.15);
         border-radius: 4px;
         transition: transform 0.15s ease-out, box-shadow 0.15s ease-out;
+        position: relative;
+        border: 2px solid rgba(100, 80, 220, 0.25);
+      }
+
+      /* Board surface lighting gradient */
+      #board-inner::before {
+        content: '';
+        position: absolute;
+        inset: 0;
+        background: linear-gradient(
+          135deg,
+          rgba(255, 255, 255, 0.06) 0%,
+          transparent 40%,
+          transparent 60%,
+          rgba(0, 0, 0, 0.15) 100%
+        );
+        pointer-events: none;
+        z-index: 1;
+        border-radius: 2px;
+      }
+
+      /* Bottom edge – visible thickness */
+      .board-edge-bottom {
+        position: absolute;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        height: 18px;
+        transform: rotateX(-90deg);
+        transform-origin: bottom center;
+        background: linear-gradient(
+          to bottom,
+          #12122a 0%,
+          #0a0a18 100%
+        );
+        border-bottom-left-radius: 4px;
+        border-bottom-right-radius: 4px;
+        border: 1px solid rgba(100, 80, 220, 0.15);
+        border-top: none;
+      }
+
+      /* Right edge – visible thickness */
+      .board-edge-right {
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        right: 0;
+        width: 18px;
+        transform: rotateY(90deg);
+        transform-origin: right center;
+        background: linear-gradient(
+          to right,
+          #0e0e22 0%,
+          #08081a 100%
+        );
+        border-top-right-radius: 4px;
+        border-bottom-right-radius: 4px;
+        border: 1px solid rgba(100, 80, 220, 0.1);
+        border-left: none;
       }
 
       .cell {
         transform-style: preserve-3d;
         transition: transform 0.08s ease, box-shadow 0.08s ease, background 0.08s ease;
         border: 1px solid rgba(255, 255, 255, 0.03);
+        box-shadow: inset 1px 1px 0 rgba(255, 255, 255, 0.02), inset -1px -1px 0 rgba(0, 0, 0, 0.15);
       }
 
       .cell-snake {

--- a/src/index.js
+++ b/src/index.js
@@ -38,6 +38,15 @@ createDivElement("board-inner", {
   borderRadius: "4px",
 }, "board");
 
+// Board thickness edges
+const edgeBottom = document.createElement("div");
+edgeBottom.className = "board-edge-bottom";
+document.getElementById("board-inner").appendChild(edgeBottom);
+
+const edgeRight = document.createElement("div");
+edgeRight.className = "board-edge-right";
+document.getElementById("board-inner").appendChild(edgeRight);
+
 /**
  * Draw the grid
  */


### PR DESCRIPTION
## Summary
- Adds visible bottom and right side faces to the board, giving it physical thickness like a tabletop platform
- Applies a surface lighting gradient that simulates light hitting the tilted board
- Adds subtle inset shadows on each cell for a tactile, embossed grid feel
- Adds a glowing purple border edge to the board perimeter

## Why this approach
The board already had perspective transforms and tilt, but the surface was completely flat — just colored squares. Adding CSS 3D-transformed edge panels (bottom + right) creates the illusion of a solid slab without any extra rendering overhead. The lighting gradient and cell emboss reinforce the depth cue at zero performance cost.

## How to test
1. Run `npx vite` and open the dev server
2. The board should appear as a raised 3D platform with visible dark side edges
3. Move the mouse over the board — the tilt interaction should still work, and the side edges should remain consistent
4. Start a game (press Enter) — snake and food cells should still pop up above the board surface
5. Verify the subtle gradient lighting across the board surface (brighter top-left, darker bottom-right)

## Notable decisions
- Edge thickness is 18px (matching cell size) — thick enough to be visible at the 45° tilt angle
- Only bottom and right edges are rendered since those are the two visible faces at the default rotateX(45deg) rotateZ(-5deg) viewing angle
- Used CSS pseudo-element for the lighting overlay to avoid adding DOM nodes inside the grid

🤖 Generated with [Claude Code](https://claude.com/claude-code)